### PR TITLE
Add support for <spoiler> tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export { Email, tokenize as emails } from './emails';
 export { Mention, tokenize as mentions } from './mentions';
 export { Link, tokenize as links } from './links';
 export { Arrows, tokenize as arrows } from './arrows';
+export { Spoiler, tokenize as spoilers } from './spoiler';

--- a/src/spoiler.test.ts
+++ b/src/spoiler.test.ts
@@ -1,0 +1,15 @@
+import { tokenize, Spoiler } from './spoiler';
+import { tableTest } from './lib/test-helpers';
+
+tableTest('spoilers', tokenize(), [
+  ['this is a <spoiler>спойлер</spoiler> indeed', [new Spoiler(10, '<spoiler>спойлер</spoiler>')]],
+  [
+    '<spoiler>123</spoiler> <Spoiler>234</SPOILER> <spoiler with attr>spoiler</spoiler>',
+    [new Spoiler(0, '<spoiler>123</spoiler>'), new Spoiler(23, '<Spoiler>234</SPOILER>')],
+  ],
+  ['<spoiler>some text', []],
+  [
+    '<spoiler>outer<spoiler>inner</spoiler></spoiler>',
+    [new Spoiler(14, '<spoiler>inner</spoiler>')],
+  ],
+]);

--- a/src/spoiler.ts
+++ b/src/spoiler.ts
@@ -1,0 +1,9 @@
+import { Token } from './types';
+import byRegexp from './lib/byRegexp';
+import { makeToken } from './lib/byRegexp';
+
+const defaultRe = /<spoiler>(?:(?!(<spoiler>|<\/spoiler>)).)*<\/spoiler>/gi;
+
+export class Spoiler extends Token {}
+
+export const tokenize = (re = defaultRe) => byRegexp(re, makeToken(Spoiler));


### PR DESCRIPTION
This PR adds support for <spoiler> tag.

Should match: `<spoiler>text</spoiler>`
Should match only inner pair: `<spoiler>outer<spoiler>inner</spoiler></spoiler>`
Should not match: `<spoiler> some text`